### PR TITLE
#2 Add travis integration for OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+os:
+  - osx
+
+language: go
+
+go:
+  - 1.6
+  - tip

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Go Keyring library
+[![Build Status](https://travis-ci.org/zalando/go-keyring.svg?branch=master)](https://travis-ci.org/zalando/go-keyring)
 [![Go Report Card](https://goreportcard.com/badge/github.com/zalando/go-keyring)](https://goreportcard.com/report/github.com/zalando/go-keyring)
 [![GoDoc](https://godoc.org/github.com/zalando/go-keyring?status.svg)](https://godoc.org/github.com/zalando/go-keyring)
 


### PR DESCRIPTION
Successful build: https://travis-ci.org/zalando/go-keyring/builds/145776271

Close #2 