### PR TITLE
#1 Run travis tests on linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,27 @@
+sudo: required
+dist: trusty
+
 os:
   - osx
+  - linux
 
 language: go
 
 go:
   - 1.6
   - tip
+
+before_install:
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      sudo apt-get -qq update
+      sudo apt-get install -y gnome-keyring
+      # use python-gnomekeyring to create the expected keyring 'login'
+      sudo apt-get install -y python-gnomekeyring
+    fi
+before_script:
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      dbus-launch /usr/bin/python -c \
+        "import gnomekeyring;gnomekeyring.create_sync('login', '');"
+    fi

--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ on **OS X**, it will test the implementation in `keyring_darwin.go`.
 We welcome contributions from the community; please use [CONTRIBUTING.md](CONTRIBUTING.md) as your guidelines for getting started. Here are some items that we'd love help with:
 
 - [Windows support](https://github.com/zalando/go-keyring/issues/3)
-- [Travis Linux](https://github.com/zalando/go-keyring/issues/1)
 - The code base
 
 Please use GitHub issues as the starting point for contributions, new ideas and/or bug reports.


### PR DESCRIPTION
This makes the tests run in a travis linux environment. It uses `python-gnomekeyring` to create the `'login'` keyring which is usually created by default on a normal desktop distro.

Fix #1 