### PR TITLE
linux: Unlock keyring on Get

### DIFF
--- a/keyring_linux.go
+++ b/keyring_linux.go
@@ -57,6 +57,11 @@ func (s secretServiceProvider) findItem(svc *ss.SecretService, service, user str
 		"service":  service,
 	}
 
+	err := svc.Unlock(collection.Path())
+	if err != nil {
+		return "", err
+	}
+
 	results, err := svc.SearchItems(collection, search)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Getting a secret from the keyring would always fail on linux if the
keyring was locked. This patch fixes the issue by unlocking the keyring
before searching for the secret.