### PR TITLE
Fallback to default secret object path

### DIFF
--- a/keyring_linux.go
+++ b/keyring_linux.go
@@ -2,7 +2,6 @@ package keyring
 
 import (
 	"fmt"
-
 	"github.com/godbus/dbus"
 	"github.com/zalando/go-keyring/secret_service"
 )
@@ -31,7 +30,7 @@ func (s secretServiceProvider) Set(service, user, pass string) error {
 
 	secret := ss.NewSecret(session.Path(), pass)
 
-	collection := svc.GetCollection("login")
+	collection := svc.GetLoginCollection()
 
 	err = svc.Unlock(collection.Path())
 	if err != nil {
@@ -50,7 +49,7 @@ func (s secretServiceProvider) Set(service, user, pass string) error {
 
 // findItem looksup an item by service and user.
 func (s secretServiceProvider) findItem(svc *ss.SecretService, service, user string) (dbus.ObjectPath, error) {
-	collection := svc.GetCollection("login")
+	collection := svc.GetLoginCollection()
 
 	search := map[string]string{
 		"username": user,


### PR DESCRIPTION
The object path `/org/freedesktop/secrets/collection/login` is not
necessarily available.

The D-Bus API reference from freedesktop.org specifies
`/org/freedesktop/secrets/aliases/default`, which is commonly used.
See: https://specifications.freedesktop.org/secret-service/ch12.html

This patch tries to accommodate both scenarios, by first checking whether
the direct path is available. If so it will be used as before, if not it
will fall back to the alias path.