### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/keyring_darwin.go
+++ b/keyring_darwin.go
@@ -47,7 +47,7 @@ func (k macOSXKeychain) Get(service, username string) (string, error) {
 	return strings.TrimSpace(fmt.Sprintf("%s", out)), nil
 }
 
-// Get gets a secret from the keyring given a service name and a user.
+// Set gets gets a secret from the keyring given a service name and a user.
 func (k macOSXKeychain) Set(service, username, password string) error {
 	return exec.Command(
 		execPathKeychain,


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?