### PR TITLE
add support for multiline passwords on all platforms

### DIFF
--- a/keyring_darwin.go
+++ b/keyring_darwin.go
@@ -15,6 +15,7 @@
 package keyring
 
 import (
+	"encoding/hex"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -44,7 +45,14 @@ func (k macOSXKeychain) Get(service, username string) (string, error) {
 		}
 		return "", err
 	}
-	return strings.TrimSpace(fmt.Sprintf("%s", out)), nil
+	// if the added secret has multiple lines, osx will hex encode it
+	trimStr := strings.TrimSpace(string(out[:]))
+	dec, err := hex.DecodeString(trimStr)
+	// if there was an error hex decoding the string, assume it's not encoded
+	if err != nil {
+		return fmt.Sprintf("%s", trimStr), nil
+	}
+	return fmt.Sprintf("%s", dec), err
 }
 
 // Get gets a secret from the keyring given a service name and a user.

--- a/keyring_test.go
+++ b/keyring_test.go
@@ -16,6 +16,28 @@ func TestSet(t *testing.T) {
 	}
 }
 
+// TestGetMultiline tests getting a multi-line password from the keyring
+func TestGetMultiLine(t *testing.T) {
+	multilinePassword := `this password
+has multiple
+lines and will be
+encoded by some keyring implementiations
+like osx`
+	err := Set(service, user, multilinePassword)
+	if err != nil {
+		t.Errorf("Should not fail, got: %s", err)
+	}
+
+	pw, err := Get(service, user)
+	if err != nil {
+		t.Errorf("Should not fail, got: %s", err)
+	}
+
+	if multilinePassword != pw {
+		t.Errorf("Expected password %s, got %s", multilinePassword, pw)
+	}
+}
+
 // TestGet tests getting a password from the keyring.
 func TestGet(t *testing.T) {
 	err := Set(service, user, password)


### PR DESCRIPTION
Bugfix for multiline password encoding on OSX.  A workaround would be the feature development of certificate stores instead of password store types, but this fix is still worth having IMHO.

tl;dr is that OSX will hex encode passwords if there are certain characters in the stream, newlines are the one I stumbled upon. Gnome-keyring doesn't have this, so multiline passwords still come out un-encoded. I have not tested windows, but am hoping your CI will pick that up if work is needed so I don't have to install a vm :)