### PR TITLE
Adding well-known prefix to encoded multiline strings

### DIFF
--- a/keyring_darwin.go
+++ b/keyring_darwin.go
@@ -53,7 +53,7 @@ func (k macOSXKeychain) Get(service, username string) (string, error) {
 	// if the string has the well-known prefix, assume it's encoded
 	if strings.HasPrefix(trimStr, encodingPrefix) {
 		dec, err := hex.DecodeString(trimStr[len(encodingPrefix):])
-		return fmt.Sprintf("%s", dec), err
+		return string(dec), err
 	}
 
 	return trimStr, nil

--- a/keyring_darwin.go
+++ b/keyring_darwin.go
@@ -52,9 +52,8 @@ func (k macOSXKeychain) Get(service, username string) (string, error) {
 	trimStr := strings.TrimSpace(string(out[:]))
 	// if the string has the well-known prefix, assume it's encoded
 	if strings.HasPrefix(trimStr, encodingPrefix) {
-		if dec, err := hex.DecodeString(trimStr[len(encodingPrefix):]); err == nil {
-			return fmt.Sprintf("%s", dec), nil
-		}
+		dec, err := hex.DecodeString(trimStr[len(encodingPrefix):])
+		return fmt.Sprintf("%s", dec), err
 	}
 
 	return trimStr, nil

--- a/keyring_test.go
+++ b/keyring_test.go
@@ -38,6 +38,24 @@ like osx`
 	}
 }
 
+// TestGetSingleLineHex tests getting a single line hex string password from the keyring.
+func TestGetSingleLineHex(t *testing.T) {
+	hexPassword := "abcdef123abcdef123"
+	err := Set(service, user, hexPassword)
+	if err != nil {
+		t.Errorf("Should not fail, got: %s", err)
+	}
+
+	pw, err := Get(service, user)
+	if err != nil {
+		t.Errorf("Should not fail, got: %s", err)
+	}
+
+	if hexPassword != pw {
+		t.Errorf("Expected password %s, got %s", hexPassword, pw)
+	}
+}
+
 // TestGet tests getting a password from the keyring.
 func TestGet(t *testing.T) {
 	err := Set(service, user, password)


### PR DESCRIPTION
Fixes #36 

Adds a "well-known prefix" and hex encodes any incoming multiline string sent to `Set()`. Updates `Get()` to only decode when the well-known prefix is present.

**Warning:** This implementation will corrupt any existing multiline strings already in the keychain! On the plus side, it should un-corrupt any non-multiline strings that are currently being corrupted by #36.

Kudos to @jaroslaw-bochniak for the tests.