### PR TITLE
Fixes error when the default collection is opened.

### DIFF
--- a/secret_service/secret_service.go
+++ b/secret_service/secret_service.go
@@ -121,7 +121,7 @@ func (s *SecretService) Unlock(collection dbus.ObjectPath) error {
 		unlocked = append(unlocked, c...)
 	}
 
-	if len(unlocked) != 1 || unlocked[0] != collection {
+	if len(unlocked) != 1 || (collection != loginCollectionAlias && unlocked[0] != collection) {
 		return fmt.Errorf("failed to unlock correct collection '%v'", collection)
 	}
 


### PR DESCRIPTION
When the default collection is opened the returned collection name is the actual name and not the alias. This happens when the collection is not named `login` and the default should be used.