### PR TITLE
[RFC] add kwalled (kde) backend and use it if available

### DIFF
--- a/keyring_linux.go
+++ b/keyring_linux.go
@@ -2,8 +2,10 @@ package keyring
 
 import (
 	"fmt"
+
 	"github.com/godbus/dbus"
-	"github.com/zalando/go-keyring/secret_service"
+	kw "github.com/zalando/go-keyring/kwallet"
+	ss "github.com/zalando/go-keyring/secret_service"
 )
 
 type secretServiceProvider struct{}
@@ -11,6 +13,13 @@ type secretServiceProvider struct{}
 // Set stores user and pass in the keyring under the defined service
 // name.
 func (s secretServiceProvider) Set(service, user, pass string) error {
+	if w, err := kw.NewKWallet(service); err == nil && w.IsAvailable() {
+		if err := w.Open(); err != nil {
+			return err
+		}
+		return w.Write(user, pass)
+	}
+
 	svc, err := ss.NewSecretService()
 	if err != nil {
 		return err
@@ -75,6 +84,22 @@ func (s secretServiceProvider) findItem(svc *ss.SecretService, service, user str
 
 // Get gets a secret from the keyring given a service name and a user.
 func (s secretServiceProvider) Get(service, user string) (string, error) {
+	if w, err := kw.NewKWallet(service); err == nil && w.IsAvailable() {
+		if err := w.Open(); err != nil {
+			return "", err
+		}
+		if b, err := w.Has(user); err != nil {
+			return "", err
+		} else if !b {
+			return "", ErrNotFound
+		}
+		pw, err := w.Read(user)
+		if err != nil {
+			return "", err
+		}
+		return pw, nil
+	}
+
 	svc, err := ss.NewSecretService()
 	if err != nil {
 		return "", err
@@ -102,6 +127,18 @@ func (s secretServiceProvider) Get(service, user string) (string, error) {
 
 // Delete deletes a secret, identified by service & user, from the keyring.
 func (s secretServiceProvider) Delete(service, user string) error {
+	if w, err := kw.NewKWallet(service); err == nil && w.IsAvailable() {
+		if err := w.Open(); err != nil {
+			return err
+		}
+		if b, err := w.Has(user); err != nil {
+			return err
+		} else if !b {
+			return ErrNotFound
+		}
+		return w.Delete(user)
+	}
+
 	svc, err := ss.NewSecretService()
 	if err != nil {
 		return err

--- a/kwallet/kwallet.go
+++ b/kwallet/kwallet.go
@@ -1,0 +1,100 @@
+package kw
+
+import (
+	"errors"
+
+	"github.com/godbus/dbus"
+)
+
+const (
+	serviceName     = "org.kde.kwalletd5"
+	servicePath     = "/modules/kwalletd5"
+	methodInterface = "org.kde.KWallet"
+)
+
+// KWallet is an interface for the KWallet dbus API.
+type KWallet struct {
+	*dbus.Conn
+	object  dbus.BusObject
+	service string
+	handle  int
+}
+
+// NewKWallet inializes a new NewKwallet object.
+func NewKWallet(service string) (*KWallet, error) {
+	conn, err := dbus.SessionBus()
+	if err != nil {
+		return nil, err
+	}
+
+	return &KWallet{
+		conn,
+		conn.Object(serviceName, servicePath),
+		service,
+		0,
+	}, nil
+}
+
+// IsAvailable checks if the kwallet is available
+func (k *KWallet) IsAvailable() bool {
+	var wallet string
+	if err := k.object.Call(methodInterface+".networkWallet", 0).Store(&wallet); err != nil {
+		return false
+	}
+	return true
+}
+
+// Open the wallet
+func (k *KWallet) Open() error {
+	var wallet string
+	if err := k.object.Call(methodInterface+".networkWallet", 0).Store(&wallet); err != nil {
+		return err
+	}
+
+	if err := k.object.Call(methodInterface+".open", 0, wallet, int64(0), k.service).Store(&k.handle); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Read a value by key
+func (k *KWallet) Read(key string) (string, error) {
+	var password string
+	if err := k.object.Call(methodInterface+".readPassword", 0, k.handle, k.service, key, k.service).Store(&password); err != nil {
+		return "", err
+	}
+	return password, nil
+}
+
+// Write a key, value pair
+func (k *KWallet) Write(key, value string) error {
+	var i int
+	if err := k.object.Call(methodInterface+".writePassword", 0, k.handle, k.service, key, value, k.service).Store(&i); err != nil {
+		return err
+	}
+	if i < 0 {
+		return errors.New("Could not write password")
+	}
+	return nil
+}
+
+// Delete a value by key
+func (k *KWallet) Delete(key string) error {
+	var i int
+	if err := k.object.Call(methodInterface+".removeEntry", 0, k.handle, k.service, key, k.service).Store(&i); err != nil {
+		return err
+	}
+	if i < 0 {
+		return errors.New("Could not delete password")
+	}
+	return nil
+}
+
+// Has a  key
+func (k *KWallet) Has(key string) (bool, error) {
+	var b bool
+	if err := k.object.Call(methodInterface+".hasEntry", 0, k.handle, k.service, key, k.service).Store(&b); err != nil {
+		return b, err
+	}
+	return b, nil
+}


### PR DESCRIPTION
the kwallet (kde) backend communicates through dbus with the kwalletd.
it is modeled after the qtkeychain implementation [1].
like qtkeychain, the keyring backend tries to get the kwallet's
'networkWallet' if this fails the 'secret service' is used as before.
kwallet is tried first as the 'secrets service' may exists on systems
running kde but it's very unlikely kwallet is running on non kde
systems.

[1] https://github.com/frankosterfeld/qtkeychain