### PR TITLE
Test umlaut passwords

### DIFF
--- a/keyring_darwin.go
+++ b/keyring_darwin.go
@@ -61,11 +61,10 @@ func (k macOSXKeychain) Get(service, username string) (string, error) {
 
 // Set stores a secret in the keyring given a service name and a user.
 func (k macOSXKeychain) Set(service, username, password string) error {
-	// if the added secret has multiple lines, osx will hex encode it
-	// identify this with a well-known prefix.
-	if strings.ContainsRune(password, '\n') {
-		password = encodingPrefix + hex.EncodeToString([]byte(password))
-	}
+	// if the added secret has multiple lines or some non ascii,
+	// osx will hex encode it on return. To avoid getting garbage, we
+	// encode all passwords
+	password = encodingPrefix + hex.EncodeToString([]byte(password))
 
 	return exec.Command(
 		execPathKeychain,

--- a/keyring_test.go
+++ b/keyring_test.go
@@ -38,6 +38,24 @@ like osx`
 	}
 }
 
+// TestGetMultiline tests getting a multi-line password from the keyring
+func TestGetUmlaut(t *testing.T) {
+	umlautPassword := "at least on OSX üöäÜÖÄß will be encoded"
+	err := Set(service, user, umlautPassword)
+	if err != nil {
+		t.Errorf("Should not fail, got: %s", err)
+	}
+
+	pw, err := Get(service, user)
+	if err != nil {
+		t.Errorf("Should not fail, got: %s", err)
+	}
+
+	if umlautPassword != pw {
+		t.Errorf("Expected password %s, got %s", umlautPassword, pw)
+	}
+}
+
 // TestGetSingleLineHex tests getting a single line hex string password from the keyring.
 func TestGetSingleLineHex(t *testing.T) {
 	hexPassword := "abcdef123abcdef123"


### PR DESCRIPTION
OS X does return an hex encoded password at least on Big Sur
currently the test will fail, since no fix is implemented yet. 