### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,17 +7,14 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
-    name: Build
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        # with Ubuntu 18.04, python-gnomekeyring has been deprecated and deleted
-        # from the archives so we need to use ubuntu-16.04.
-        # Do not forget to update Install Dependencies (Linux) step if the version
-        # of ubuntu is changed.
-        # https://launchpad.net/ubuntu/+source/gnome-python-desktop/+publishinghistory
-        os: [ubuntu-16.04, macOS-latest, windows-latest]
+  build-linux:
+    name: Build (ubuntu-latest)
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:latest
+      options: --privileged
+      env:
+        DEBIAN_FRONTEND: noninteractive
 
     steps:
     - name: Check out code into $GITHUB_WORKSPACE directory
@@ -26,20 +23,51 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.15
+        go-version: ^1.16
       id: go
+
+    - name: Install Dependencies
+      run: |
+        apt-get update
+        apt-get install -y gnome-keyring build-essential ca-certificates
+        mkdir -p /github/home/.cache/
+        mkdir -p /github/home/.local/share/keyrings/
+        chmod 700 -R /github/home/.local/
 
     - name: Get dependencies
       run: |
         go get -v -t -d ./...
 
-    - name: Install Dependencies (Linux)
+    - name: Build
       run: |
-        sudo apt-get update
-        sudo apt-get install python-gnomekeyring
-        sudo apt-get install gnome-keyring
-        dbus-launch /usr/bin/python -c "import gnomekeyring;gnomekeyring.create_sync('login', '');"
-      if: matrix.os == 'ubuntu-16.04'
+        go build -v ./...
+
+    - name: Test
+      run: |
+        echo 'somecredstorepass' | gnome-keyring-daemon --unlock
+        go test -v ./...
+      shell: dbus-run-session -- bash --noprofile --norc -eo pipefail {0}
+
+  build-other:
+    name: Build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macOS-latest, windows-latest]
+
+    steps:
+    - name: Check out code into $GITHUB_WORKSPACE directory
+      uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.16
+      id: go
+
+    - name: Get dependencies
+      run: |
+        go get -v -t -d ./...
 
     - name: Build
       run: |


### PR DESCRIPTION
## Changes

In github workflows:
- Bump golang version from `^1.15` to `^1.16` because `1.15` is no longer supported.
- Bump `ubuntu` to `latest` because `16.04` is removed.

## How to test

Tested with the forked version: https://github.com/nhatthm/go-keyring/runs/3522332469?check_suite_focus=true