### PR TITLE
Set keychain password on darwin via interactive mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/zalando/go-keyring
 go 1.13
 
 require (
+	github.com/alessio/shellescape v1.4.1
 	github.com/danieljoos/wincred v1.1.0
 	github.com/godbus/dbus/v5 v5.0.3
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
+github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/danieljoos/wincred v1.1.0 h1:3RNcEpBg4IhIChZdFRSdlQt1QjCp1sMAPIrOnm7Yf8g=
 github.com/danieljoos/wincred v1.1.0/go.mod h1:XYlo+eRTsVA9aHGp7NGjFkPla4m+DCL7hqDjlFjiygg=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/keyring_darwin.go
+++ b/keyring_darwin.go
@@ -17,8 +17,11 @@ package keyring
 import (
 	"encoding/hex"
 	"fmt"
+	"io"
 	"os/exec"
 	"strings"
+
+	"github.com/alessio/shellescape"
 )
 
 const (
@@ -66,13 +69,27 @@ func (k macOSXKeychain) Set(service, username, password string) error {
 	// encode all passwords
 	password = encodingPrefix + hex.EncodeToString([]byte(password))
 
-	return exec.Command(
-		execPathKeychain,
-		"add-generic-password",
-		"-U", //update if exists
-		"-s", service,
-		"-a", username,
-		"-w", password).Run()
+	cmd := exec.Command(execPathKeychain, "-i")
+	stdIn, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+
+	if err = cmd.Start(); err != nil {
+		return err
+	}
+
+	command := fmt.Sprintf("add-generic-password -U -s %s -a %s -w %s\n", shellescape.Quote(service), shellescape.Quote(username), shellescape.Quote(password))
+	if _, err := io.WriteString(stdIn, command); err != nil {
+		return err
+	}
+
+	if err = stdIn.Close(); err != nil {
+		return err
+	}
+
+	err = cmd.Wait()
+	return err
 }
 
 // Delete deletes a secret, identified by service & user, from the keyring.


### PR DESCRIPTION
This prevents the password from being exposed in the system's process list.

This is a follow up to https://github.com/zalando/go-keyring/pull/26/ with escaping implemented. Closes #24.