### PR TITLE
fix: fix adding large keys truncates

### DIFF
--- a/keyring_darwin.go
+++ b/keyring_darwin.go
@@ -16,8 +16,6 @@ package keyring
 
 import (
 	"encoding/hex"
-	"fmt"
-	"io"
 	"os/exec"
 	"strings"
 
@@ -69,26 +67,17 @@ func (k macOSXKeychain) Set(service, username, password string) error {
 	// encode all passwords
 	password = encodingPrefix + hex.EncodeToString([]byte(password))
 
-	cmd := exec.Command(execPathKeychain, "-i")
-	stdIn, err := cmd.StdinPipe()
-	if err != nil {
-		return err
-	}
-
-	if err = cmd.Start(); err != nil {
-		return err
-	}
-
-	command := fmt.Sprintf("add-generic-password -U -s %s -a %s -w %s\n", shellescape.Quote(service), shellescape.Quote(username), shellescape.Quote(password))
-	if _, err := io.WriteString(stdIn, command); err != nil {
-		return err
-	}
-
-	if err = stdIn.Close(); err != nil {
-		return err
-	}
-
-	err = cmd.Wait()
+	_, err := exec.Command(
+		execPathKeychain,
+		"add-generic-password",
+		"-U",
+		"-s",
+		shellescape.Quote(service),
+		"-a",
+		shellescape.Quote(username),
+		"-w",
+		shellescape.Quote(password),
+	).Output()
 	return err
 }
 


### PR DESCRIPTION
fixes #84

Appears to be an issue with darwin interactive mode of /usr/bin/security, where the key is limited in size. Using non-interactive and invoking command directly functions correctly.