### PR TITLE
Added support for prompt unlock broadcast rather than just unicast

### DIFF
--- a/secret_service/secret_service.go
+++ b/secret_service/secret_service.go
@@ -199,10 +199,7 @@ func (s *SecretService) handlePrompt(prompt dbus.ObjectPath) (bool, dbus.Variant
 		}
 
 		defer func(s *SecretService, options ...dbus.MatchOption) {
-			err := s.RemoveMatchSignal(options...)
-			if err != nil {
-
-			}
+			_ = s.RemoveMatchSignal(options...)
 		}(s, dbus.WithMatchObjectPath(prompt), dbus.WithMatchInterface(promptInterface))
 
 		promptSignal := make(chan *dbus.Signal, 1)

--- a/secret_service/secret_service.go
+++ b/secret_service/secret_service.go
@@ -191,6 +191,20 @@ func (s *SecretService) handlePrompt(prompt dbus.ObjectPath) (bool, dbus.Variant
 			return false, dbus.MakeVariant(""), err
 		}
 
+		err = s.AddMatchSignal(dbus.WithMatchObjectPath(prompt),
+			dbus.WithMatchInterface(promptInterface),
+		)
+		if err != nil {
+			return false, dbus.MakeVariant(""), err
+		}
+
+		defer func(s *SecretService, options ...dbus.MatchOption) {
+			err := s.RemoveMatchSignal(options...)
+			if err != nil {
+
+			}
+		}(s, dbus.WithMatchObjectPath(prompt), dbus.WithMatchInterface(promptInterface))
+
 		promptSignal := make(chan *dbus.Signal, 1)
 		s.Signal(promptSignal)
 


### PR DESCRIPTION
Currently, when waiting for a prompt, it will block indefinitely unless the prompt sends back a **unicast** `Completed` signal, however that is not the standard. 

Though several do, such as gnome keyring, we cannot assume that all implementations of the Secret Service API will do this. 

For instance, KeepassXC is a popular password management tool that also implements the Secret Service and it uses a broadcast (destination field is null) message to signal back that a prompt has been completed or dismissed instead of a unicast message (direct to the original sender of the prompt). 
The discussion here is relevant: https://github.com/keepassxreboot/keepassxc/issues/7759 

The interesting points referenced there are [this documentation section](https://dbus.freedesktop.org/doc/dbus-specification.html#message-bus-routing), specifically citing:

> When the message bus receives a signal, if the DESTINATION field is absent, it is considered to be a broadcast signal, and is sent to all applications with message matching rules that match the message. Most signal messages are broadcasts, and no other message types currently defined in this specification may be broadcast.

> Unicast signal messages (those with a DESTINATION field) are not commonly used, but they are treated like any unicast message: they are delivered to the specified receipient, regardless of its match rules. One use for unicast signals is to avoid a race condition in which a signal is emitted before the intended recipient can call [the section called “org.freedesktop.DBus.AddMatch”](https://dbus.freedesktop.org/doc/dbus-specification.html#bus-messages-add-match) to receive that signal: if the signal is sent directly to that recipient using a unicast message, it does not need to add a match rule at all, and there is no race condition. Another use for unicast signals, on message buses whose security policy prevents eavesdropping, is to send sensitive information which should only be visible to one recipient.

Thus, the preferred behavior appears to be leaving support for unicast messages, but also ensuring to receive broadcast ones, which is what I've added support for here.

Very open to discussion on the exact implementation on this and happy to discuss any ideas about specifics. 🙂

However, you'll note that it's a pretty isolated case and doesn't touch much of the code. 