### PR TITLE
Fix suspected race condition in prompt handling

### DIFF
--- a/secret_service/secret_service.go
+++ b/secret_service/secret_service.go
@@ -186,12 +186,7 @@ func (s *SecretService) CreateItem(collection dbus.BusObject, label string, attr
 // the prompt to the user.
 func (s *SecretService) handlePrompt(prompt dbus.ObjectPath) (bool, dbus.Variant, error) {
 	if prompt != dbus.ObjectPath("/") {
-		err := s.Object(serviceName, prompt).Call(promptInterface+".Prompt", 0, "").Err
-		if err != nil {
-			return false, dbus.MakeVariant(""), err
-		}
-
-		err = s.AddMatchSignal(dbus.WithMatchObjectPath(prompt),
+		err := s.AddMatchSignal(dbus.WithMatchObjectPath(prompt),
 			dbus.WithMatchInterface(promptInterface),
 		)
 		if err != nil {
@@ -204,6 +199,11 @@ func (s *SecretService) handlePrompt(prompt dbus.ObjectPath) (bool, dbus.Variant
 
 		promptSignal := make(chan *dbus.Signal, 1)
 		s.Signal(promptSignal)
+
+		err = s.Object(serviceName, prompt).Call(promptInterface+".Prompt", 0, "").Err
+		if err != nil {
+			return false, dbus.MakeVariant(""), err
+		}
 
 		signal := <-promptSignal
 		switch signal.Name {


### PR DESCRIPTION
## Description

Fixes https://github.com/zalando/go-keyring/issues/104

The current approach to handling prompts involves calling for a prompt and then registering a signal handler for a response that indicates the prompt had completed. In most cases, if the user were to take action, this would be quite slow. However, in the case of automatic responses to the prompt, the signal response may appear before the signal handler is configured, resulting in blocking forever.

This commit moves the call for a prompt after the signal handling has been configured, closing the race window.

### Reviewer Notes

I'll admit that I'm not very familiar with all the nuances of dbus or this library so it's entirely possible I've missed something. We've had three reports over on https://github.com/cli/cli/issues/8802 that this has resolved the issue they were facing but I can't say for sure that there's not some unintended side effects.