### PR TITLE
Fix typo in documentation

### DIFF
--- a/secret_service/secret_service.go
+++ b/secret_service/secret_service.go
@@ -182,7 +182,7 @@ func (s *SecretService) CreateItem(collection dbus.BusObject, label string, attr
 }
 
 // handlePrompt checks if a prompt should be handles and handles it by
-// triggering the prompt and waiting for the Sercret service daemon to display
+// triggering the prompt and waiting for the Secret service daemon to display
 // the prompt to the user.
 func (s *SecretService) handlePrompt(prompt dbus.ObjectPath) (bool, dbus.Variant, error) {
 	if prompt != dbus.ObjectPath("/") {


### PR DESCRIPTION
Simple typo fix in `secret_service.go`.