### PR TITLE
fix(readme): remove extra trailing slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,4 +144,4 @@ Thanks to:
 
 See [LICENSE](LICENSE) file.
 
-[SecretService]: https://specifications.freedesktop.org/secret-service-spec/latest//
+[SecretService]: https://specifications.freedesktop.org/secret-service-spec/latest/


### PR DESCRIPTION
Fixes #120 

This commit removes an extra trailing slash that was committed in #120. The existing link works, but it shouldn't end with two trailing slashes.