### PR TITLE
fix(secret_service): auto-detect `content_type` in `NewSecret()` based on UTF-8 validity

### DIFF
--- a/secret_service/secret_service.go
+++ b/secret_service/secret_service.go
@@ -1,9 +1,9 @@
 package ss
 
 import (
-	"fmt"
-
 	"errors"
+	"fmt"
+	"unicode/utf8"
 
 	dbus "github.com/godbus/dbus/v5"
 )
@@ -32,11 +32,18 @@ type Secret struct {
 
 // NewSecret initializes a new Secret.
 func NewSecret(session dbus.ObjectPath, secret string) Secret {
+	value := []byte(secret)
+
+	contentType := "application/octet-stream"
+	if utf8.Valid(value) {
+		contentType = "text/plain; charset=utf-8"
+	}
+
 	return Secret{
 		Session:     session,
 		Parameters:  []byte{},
-		Value:       []byte(secret),
-		ContentType: "text/plain; charset=utf8",
+		Value:       value,
+		ContentType: contentType,
 	}
 }
 

--- a/secret_service/secret_service_test.go
+++ b/secret_service/secret_service_test.go
@@ -1,0 +1,62 @@
+package ss
+
+import (
+	"testing"
+
+	dbus "github.com/godbus/dbus/v5"
+)
+
+const testSession = dbus.ObjectPath("/session")
+
+// TestNewSecretTextContent tests that valid UTF-8 strings get text/plain content type.
+func TestNewSecretTextContent(t *testing.T) {
+	secret := NewSecret(testSession, "plain text password")
+
+	expected := "text/plain; charset=utf-8"
+	if secret.ContentType != expected {
+		t.Errorf("Expected content type %s, got %s", expected, secret.ContentType)
+	}
+}
+
+// TestNewSecretBinaryContent tests that non-UTF-8 data gets application/octet-stream content type.
+func TestNewSecretBinaryContent(t *testing.T) {
+	secret := NewSecret(testSession, string([]byte{0x1f, 0x8b, 0x08, 0x00, 0xff, 0xfe}))
+
+	expected := "application/octet-stream"
+	if secret.ContentType != expected {
+		t.Errorf("Expected content type %s, got %s", expected, secret.ContentType)
+	}
+}
+
+// TestNewSecretEmptyString tests that an empty string gets text/plain content type.
+func TestNewSecretEmptyString(t *testing.T) {
+	secret := NewSecret(testSession, "")
+
+	expected := "text/plain; charset=utf-8"
+	if secret.ContentType != expected {
+		t.Errorf("Expected content type %s, got %s", expected, secret.ContentType)
+	}
+}
+
+// TestNewSecretUnicodeContent tests that valid UTF-8 with non-ASCII chars gets text/plain content type.
+func TestNewSecretUnicodeContent(t *testing.T) {
+	secret := NewSecret(testSession, "passwort mit Ümlauten äöü")
+
+	expected := "text/plain; charset=utf-8"
+	if secret.ContentType != expected {
+		t.Errorf("Expected content type %s, got %s", expected, secret.ContentType)
+	}
+}
+
+// TestNewSecretValuePreserved tests that the secret value and session are stored correctly.
+func TestNewSecretValuePreserved(t *testing.T) {
+	input := "test secret"
+	secret := NewSecret(testSession, input)
+
+	if string(secret.Value) != input {
+		t.Errorf("Expected value %s, got %s", input, string(secret.Value))
+	}
+	if secret.Session != testSession {
+		t.Errorf("Expected session %s, got %s", testSession, secret.Session)
+	}
+}


### PR DESCRIPTION
## Summary

`NewSecret()` hardcodes `content_type="text/plain; charset=utf8"` for all secrets. Providers that interpret this field (ksecretd, KeePassXC) run binary values through a UTF-8 decoder, silently replacing invalid bytes with U+FFFD. This destroys any non-UTF-8 data stored via go-keyring on KDE — gzip-compressed OAuth tokens, binary blobs, etc.

Fixes #143

## What changed

`NewSecret()` now auto-detects `content_type` based on UTF-8 validity:

```go
contentType := "application/octet-stream"
if utf8.Valid(value) {
    contentType = "text/plain; charset=utf-8"
}
```

This addresses @michaelk83's [concern](https://github.com/zalando/go-keyring/issues/143#issuecomment-4538002627) — blindly defaulting to `application/octet-stream` would break KeePassXC for text secrets (passwords become opaque attachments instead of showing in the Password field). Auto-detect is a safe compromise:

- **Text passwords** (majority of use cases) → `text/plain; charset=utf-8` → works everywhere as before
- **Binary data** (gzip tokens, etc.) → `application/octet-stream` → ksecretd takes the binary path, no corruption
- **Backwards compatible on read** — `GetSecret` returns whatever `content_type` was stored; go-keyring doesn't check it on read

## How verified

- Unit tests for `NewSecret()`: text, binary, empty string, unicode
- Integration-tested on ksecretd (KDE 6, Plasma 6.4) — binary round-trip PASS with `application/octet-stream`, FAIL with `text/plain`
- Integration-tested on gnome-keyring-daemon — both content types PASS (ignores `content_type`)

## MRE

Standalone D-Bus round-trip test — no go-keyring dependency, just `godbus`. Stores gzip-compressed data with both content types against every reachable provider.

```
go run .
```

KDE (ksecretd):
```
text/plain; charset=utf8           FAIL  (stored 53 → got 83 bytes)
application/octet-stream           PASS  (53 bytes round-tripped OK)
```

GNOME (gnome-keyring-daemon):
```
text/plain; charset=utf8           PASS  (53 bytes round-tripped OK)
application/octet-stream           PASS  (53 bytes round-tripped OK)
```

<details>
<summary>main.go</summary>

```go
package main

import (
	"bytes"
	"compress/gzip"
	"fmt"
	"os"
	"strings"

	dbus "github.com/godbus/dbus/v5"
)

type secret struct {
	Session     dbus.ObjectPath
	Parameters  []byte
	Value       []byte
	ContentType string `dbus:"content_type"`
}

func main() {
	conn, err := dbus.SessionBus()
	if err != nil {
		fmt.Fprintf(os.Stderr, "dbus: %v\n", err)
		os.Exit(2)
	}

	providers := discoverProviders(conn)
	if len(providers) == 0 {
		fmt.Fprintln(os.Stderr, "no Secret Service provider found on the session bus")
		os.Exit(2)
	}

	var buf bytes.Buffer
	w := gzip.NewWriter(&buf)
	_, _ = w.Write([]byte("simulated OAuth token payload"))
	_ = w.Close()
	payload := buf.Bytes()

	failed := false
	for i, prov := range providers {
		if i > 0 {
			fmt.Println()
		}
		fmt.Printf("--- %s (%s) ---\n", prov[0], prov[1])
		if !testProvider(conn, prov[0], payload) {
			failed = true
		}
	}
	if failed {
		os.Exit(1)
	}
}

func testProvider(conn *dbus.Conn, busName string, payload []byte) bool {
	const (
		path       = "/org/freedesktop/secrets"
		collection = "/org/freedesktop/secrets/aliases/default"
	)

	svc := conn.Object(busName, path)

	var discard dbus.Variant
	var session dbus.ObjectPath
	err := svc.Call("org.freedesktop.Secret.Service.OpenSession", 0,
		"plain", dbus.MakeVariant(""),
	).Store(&discard, &session)
	if err != nil {
		fmt.Fprintf(os.Stderr, "  OpenSession: %v\n", err)
		return false
	}
	defer conn.Object(busName, session).Call("org.freedesktop.Secret.Session.Close", 0)

	var unlocked []dbus.ObjectPath
	var prompt dbus.ObjectPath
	err = svc.Call("org.freedesktop.Secret.Service.Unlock", 0,
		[]dbus.ObjectPath{collection},
	).Store(&unlocked, &prompt)
	if err != nil {
		fmt.Fprintf(os.Stderr, "  Unlock: %v\n", err)
		return false
	}

	pass1 := roundTrip(conn, busName, collection, session, payload, "text/plain; charset=utf8")
	pass2 := roundTrip(conn, busName, collection, session, payload, "application/octet-stream")
	return pass1 && pass2
}

func roundTrip(conn *dbus.Conn, busName string, collection, session dbus.ObjectPath, payload []byte, contentType string) bool {
	tag := strings.ReplaceAll(contentType, "/", "-")

	props := map[string]dbus.Variant{
		"org.freedesktop.Secret.Item.Label": dbus.MakeVariant("mre-" + tag),
		"org.freedesktop.Secret.Item.Attributes": dbus.MakeVariant(
			map[string]string{"service": "go-keyring-mre", "username": tag},
		),
	}

	sec := secret{
		Session:     session,
		Parameters:  []byte{},
		Value:       payload,
		ContentType: contentType,
	}

	var item, prompt dbus.ObjectPath
	err := conn.Object(busName, collection).
		Call("org.freedesktop.Secret.Collection.CreateItem", 0, props, sec, true).
		Store(&item, &prompt)
	if err != nil {
		fmt.Fprintf(os.Stderr, "  CreateItem: %v\n", err)
		return false
	}
	defer conn.Object(busName, item).Call("org.freedesktop.Secret.Item.Delete", 0)

	var got secret
	err = conn.Object(busName, item).
		Call("org.freedesktop.Secret.Item.GetSecret", 0, session).
		Store(&got)
	if err != nil {
		fmt.Fprintf(os.Stderr, "  GetSecret: %v\n", err)
		return false
	}

	if bytes.Equal(payload, got.Value) {
		fmt.Printf("%-34s PASS  (%d bytes round-tripped OK)\n", contentType, len(payload))
		return true
	}

	fmt.Printf("%-34s FAIL  (stored %d → got %d bytes)\n",
		contentType, len(payload), len(got.Value))
	return false
}

func discoverProviders(conn *dbus.Conn) [][2]string {
	seen := map[uint32]bool{}
	var result [][2]string

	for _, name := range []string{"org.freedesktop.secrets", "org.kde.ksecretd"} {
		var pid uint32
		err := conn.BusObject().
			Call("org.freedesktop.DBus.GetConnectionUnixProcessID", 0, name).
			Store(&pid)
		if err != nil || seen[pid] {
			continue
		}
		seen[pid] = true

		proc := fmt.Sprintf("pid-%d", pid)
		if comm, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid)); err == nil {
			proc = strings.TrimSpace(string(comm))
		}
		result = append(result, [2]string{name, proc})
	}

	return result
}
```

</details>
